### PR TITLE
enh: menubox for specialization & remove availability

### DIFF
--- a/apps/engage-hub-service/src/trainer-request/dto/create-trainer-request.dto.ts
+++ b/apps/engage-hub-service/src/trainer-request/dto/create-trainer-request.dto.ts
@@ -19,10 +19,6 @@ export class CreateTrainerRequestDto {
   certifications: CreateCertificationDto[];
 
   @IsNotEmpty()
-  @IsString()
-  availability: string;
-
-  @IsNotEmpty()
   @IsEnum(SpecializationTypes.getAllSpecializations(), {
     message: `specialization must be one of: ${SpecializationTypes.getAllSpecializations().join(', ')}`,
   })

--- a/apps/engage-hub-service/src/trainer-request/entities/trainer-request.entity.ts
+++ b/apps/engage-hub-service/src/trainer-request/entities/trainer-request.entity.ts
@@ -29,9 +29,6 @@ export class TrainerRequest {
   )
   certifications: Certification[];
 
-  @Column()
-  availability: string;
-
   @Column({
     type: 'enum',
     enum: SpecializationTypes.getAllSpecializations(),

--- a/apps/frontend/app/Profile/forms/CoachRequestForm.tsx
+++ b/apps/frontend/app/Profile/forms/CoachRequestForm.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { useForm, useFieldArray } from 'react-hook-form';
+import { useForm, useFieldArray} from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { coachRequestSchema, CoachRequest } from './coach-request';
 import FormInput from '../../routines/create/components/FormInput';
 import Button from '@/app/components/Button';
+import FormDropDown from "../../routines/create/components/FormDropDown";
 
 interface Props {
   onSubmit: (data: CoachRequest) => Promise<void>;
@@ -12,12 +13,16 @@ interface Props {
 }
 
 export const CoachRequestForm: React.FC<Props> = ({ onSubmit, onClose, isLoading }) => {
-  const { control, handleSubmit, formState: { errors, isValid } } = useForm<CoachRequest>({
+  const { 
+    register, 
+    control, 
+    handleSubmit, 
+    formState: { errors, isValid } 
+  } = useForm<CoachRequest>({
     resolver: zodResolver(coachRequestSchema),
     mode: 'onChange',
     defaultValues: {
       experience: '',
-      availability: '',
       specialization: '',
       certifications: [{ name: '', issuedBy: '', issueDate: '' }]
     }
@@ -38,20 +43,14 @@ export const CoachRequestForm: React.FC<Props> = ({ onSubmit, onClose, isLoading
         error={errors.experience}
       />
       
-      <FormInput
-        name="availability"
-        control={control}
-        label="Availability"
-        type="text"
-        error={errors.availability}
-      />
-      
-      <FormInput
+      <FormDropDown
         name="specialization"
         control={control}
         label="Specialization"
-        type="text"
+        defaultMessage="Select an Option"
+        options={["Weightlifting", "Resistance Training", "Cardio", "Yoga", "Pilates", "Crossfit", "HIIT", "Functional Training", "Boxing", "Martial Arts"]}
         error={errors.specialization}
+        register={register} 
       />
 
       <div className="space-y-4">

--- a/apps/frontend/app/Profile/forms/coach-request.ts
+++ b/apps/frontend/app/Profile/forms/coach-request.ts
@@ -8,10 +8,16 @@ export const certificationSchema = z.object({
 
 export const coachRequestSchema = z.object({
   experience: z.string().min(1, "Experience is required"),
-  availability: z.string().min(1, "Availability is required"),
-  specialization: z.string().min(1, "Specialization is required"),
-  certifications: z.array(certificationSchema).min(1, "At least one certification is required")
+  specialization: z
+    .enum(["weightlifting", "resistance training", "cardio", "yoga", "pilates", "crossfit", "hiit", "functional training", "boxing", "martial arts"])
+    .transform((val) => val.split(' ')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(' ')
+    ),
+  certifications: z.array(certificationSchema).min(1, "At least one certification is required"),
 });
+
 
 export type CoachRequest = z.infer<typeof coachRequestSchema>;
 export type Certification = z.infer<typeof certificationSchema>;
+

--- a/apps/frontend/app/routines/create/components/FormDropDown.tsx
+++ b/apps/frontend/app/routines/create/components/FormDropDown.tsx
@@ -4,20 +4,20 @@ import {
   Controller,
   FieldError,
   UseFormRegister,
+  Path,
 } from "react-hook-form";
-import { FormValues } from "./RoutineFormWrapper";
 
-interface Props {
-  name: string;
-  control: Control<any>;
+interface Props<T extends Record<string, any>> {
+  name: Path<T>;
+  control: Control<T>;
   label: string;
   defaultMessage: string;
   options: string[];
   error?: FieldError;
-  register: UseFormRegister<FormValues>;
+  register: UseFormRegister<T>;
 }
 
-function FormDropDown({
+function FormDropDown<T extends Record<string, any>>({
   name,
   control,
   label,
@@ -25,7 +25,7 @@ function FormDropDown({
   options,
   error,
   register,
-}: Props) {
+}: Props<T>) {
   return (
     <div className="flex flex-col gap-2">
       <Controller
@@ -35,8 +35,8 @@ function FormDropDown({
           <label className="flex flex-col text-xs gap-2">
             {label}
             <select
-              className={`border border-whiteGray bg-transparent p-2 rounded-md h-12 cursor-pointer`}
-              {...register("difficultLevel")}
+              className="border border-whiteGray bg-transparent p-2 rounded-md h-12 cursor-pointer"
+              {...register(name)}
               defaultValue="Select an Option"
             >
               <option disabled className="hidden">


### PR DESCRIPTION
This is just a simple change:
- Removed the “availability” field from the trainer request in both front end and backend.
- Now the specialization field in the form uses a dropdown form with the available options.